### PR TITLE
add basic optional resource discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.23.0
 toolchain go1.23.5
 
 require (
+	github.com/samber/lo v1.49.1
+	github.com/santhosh-tekuri/jsonschema v1.2.4
 	github.com/stretchr/testify v1.10.0
 	helm.sh/helm/v3 v3.17.0
 	k8s.io/apimachinery v0.32.1

--- a/go.sum
+++ b/go.sum
@@ -306,6 +306,10 @@ github.com/rubenv/sql-migrate v1.7.1 h1:f/o0WgfO/GqNuVg+6801K/KW3WdDSupzSjDYODmi
 github.com/rubenv/sql-migrate v1.7.1/go.mod h1:Ob2Psprc0/3ggbM6wCzyYVFFuc6FyZrb2AS+ezLDFb4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.49.1 h1:4BIFyVfuQSEpluc7Fua+j1NolZHiEHEpaSEKdsH0tew=
+github.com/samber/lo v1.49.1/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
+github.com/santhosh-tekuri/jsonschema v1.2.4 h1:hNhW8e7t+H1vgY+1QeEQpveR6D4+OwKPXCfD2aieJis=
+github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/helm/chart.go
+++ b/helm/chart.go
@@ -5,6 +5,12 @@
 package helm
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/jaypipes/kube-inspect/debug"
+	"helm.sh/helm/v3/pkg/action"
 	helmchart "helm.sh/helm/v3/pkg/chart"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -14,18 +20,47 @@ import (
 // and therefore exposes all of that struct's methods and metadata getters.
 type Chart struct {
 	*helmchart.Chart
+	rendered    bool
+	manifest    *bytes.Buffer
+	inspectOpts *InspectOptions
 	// resources is a slice of Kubernetes resources represented as
 	// `unstructured.Unstructured` documents that was found in the
 	// rendered/synthesized Helm Chart.
 	resources []*unstructured.Unstructured
 }
 
-// Resources returns a slice of Kubernetes resources installed by the Helm
-// Chart that match a supplied filter.
-func (c *Chart) Resources() []*unstructured.Unstructured {
-	res := []*unstructured.Unstructured{}
-	for _, r := range c.resources {
-		res = append(res, r)
+// render installs the Helm chart and sets the Chart.manifest to a buffer
+// containing a YAML document containing zero or more Kubernetes resource
+// manifests that have been synthesized by running a dry-running install of the
+// Helm Chart.
+func (c *Chart) render(
+	ctx context.Context,
+) error {
+	hc := c.Chart
+	if hc == nil {
+		return fmt.Errorf("cannot render nil chart.")
 	}
-	return res
+	if c.rendered {
+		return nil
+	}
+	ctx = debug.PushTrace(ctx, "helm:chart:render")
+	defer debug.PopTrace(ctx)
+	installer := action.NewInstall(&action.Configuration{})
+	installer.ClientOnly = true
+	installer.DryRun = true
+	installer.ReleaseName = "kube-inspect"
+	installer.IncludeCRDs = true
+	installer.Namespace = "default"
+	installer.DisableHooks = true
+	opts := c.inspectOpts
+	if opts.values != nil {
+		debug.Printf(ctx, "using value overrides: %v\n", opts.values)
+	}
+	release, err := installer.Run(hc, opts.values)
+	if err != nil {
+		return err
+	}
+	c.manifest = bytes.NewBuffer([]byte(release.Manifest))
+	c.rendered = true
+	return nil
 }

--- a/helm/inspect_test.go
+++ b/helm/inspect_test.go
@@ -43,7 +43,8 @@ func TestInspectURL(t *testing.T) {
 
 	require.NotNil(c.Metadata)
 	assert.Equal("nginx", c.Metadata.Name)
-	resources := c.Resources()
+	resources, err := c.Resources(ctx)
+	require.Nil(err)
 	resourceKinds := []string{}
 	for _, r := range resources {
 		resourceKinds = append(resourceKinds, r.GetKind())
@@ -61,12 +62,14 @@ func TestInspectHelmSDKChart(t *testing.T) {
 	require.Nil(err)
 	hc, err := loader.LoadArchive(tf)
 	require.Nil(err)
-	c, err := kihelm.Inspect(context.TODO(), hc)
+	ctx := context.TODO()
+	c, err := kihelm.Inspect(ctx, hc)
 	require.Nil(err)
 
 	require.NotNil(c.Metadata)
 	assert.Equal("nginx", c.Metadata.Name)
-	resources := c.Resources()
+	resources, err := c.Resources(ctx)
+	require.Nil(err)
 	resourceKinds := []string{}
 	for _, r := range resources {
 		resourceKinds = append(resourceKinds, r.GetKind())
@@ -80,12 +83,14 @@ func TestInspectHelmSDKChart(t *testing.T) {
 func TestInspectChartDir(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	c, err := kihelm.Inspect(context.TODO(), nginxLocalChartDir)
+	ctx := context.TODO()
+	c, err := kihelm.Inspect(ctx, nginxLocalChartDir)
 	require.Nil(err)
 
 	require.NotNil(c.Metadata)
 	assert.Equal("nginx", c.Metadata.Name)
-	resources := c.Resources()
+	resources, err := c.Resources(ctx)
+	require.Nil(err)
 	resourceKinds := []string{}
 	for _, r := range resources {
 		resourceKinds = append(resourceKinds, r.GetKind())
@@ -101,12 +106,14 @@ func TestInspectIOReader(t *testing.T) {
 	assert := assert.New(t)
 	tf, err := os.Open(nginxLocalChartPath)
 	require.Nil(err)
-	c, err := kihelm.Inspect(context.TODO(), tf)
+	ctx := context.TODO()
+	c, err := kihelm.Inspect(ctx, tf)
 	require.Nil(err)
 
 	require.NotNil(c.Metadata)
 	assert.Equal("nginx", c.Metadata.Name)
-	resources := c.Resources()
+	resources, err := c.Resources(ctx)
+	require.Nil(err)
 	resourceKinds := []string{}
 	for _, r := range resources {
 		resourceKinds = append(resourceKinds, r.GetKind())
@@ -121,15 +128,17 @@ func TestInspectWithValues(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	overrides := "pdb.create=true,serviceAccount.create=true"
+	ctx := context.TODO()
 	c, err := kihelm.Inspect(
-		context.TODO(), nginxLocalChartDir,
+		ctx, nginxLocalChartDir,
 		kihelm.WithValues(overrides),
 	)
 	require.Nil(err)
 
 	require.NotNil(c.Metadata)
 	assert.Equal("nginx", c.Metadata.Name)
-	resources := c.Resources()
+	resources, err := c.Resources(ctx)
+	require.Nil(err)
 	resourceKinds := []string{}
 	for _, r := range resources {
 		resourceKinds = append(resourceKinds, r.GetKind())

--- a/helm/resource.go
+++ b/helm/resource.go
@@ -1,0 +1,139 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package helm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jaypipes/kube-inspect/debug"
+	"github.com/jaypipes/kube-inspect/kube"
+	"github.com/samber/lo"
+	"github.com/santhosh-tekuri/jsonschema"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Resources returns a slice of Kubernetes resources installed by the Helm
+// Chart that match a supplied filter.
+func (c *Chart) Resources(
+	ctx context.Context,
+) ([]*unstructured.Unstructured, error) {
+	if !c.rendered {
+		if err := c.render(ctx); err != nil {
+			return nil, err
+		}
+	}
+	// Unfortunately, the helm sdk-go Release.Info.Resources map is empty when
+	// "installing" in dry-run mode (which is necessary to render the templates
+	// but not actually install anything). So we need to manually construct the
+	// set of Kubernetes resources by processing the rendered multi-document
+	// YAML manifest.
+	resources, err := kube.ResourcesFromManifest(ctx, c.manifest)
+	if err != nil {
+		return nil, err
+	}
+	c.resources = resources
+	return c.resources, nil
+}
+
+// OptionalResource contains information about a Kubernetes Resource that the
+// Helm Chart may install.
+type OptionalResource struct {
+	// GroupKind is the Kubernetes GroupKind that was identified for the
+	// Resource during inspection.
+	GroupKind schema.GroupKind
+	// DefaultName is the name of the Resource that would be rendered with the
+	// default values collection.
+	DefaultName string
+	// ValueToggle is the strvals notation for the configuration value that
+	// toggles the creation or enablement of this Resource. For example, assume
+	// the very common practice of optionally creating a ServiceAccount
+	// Resource when the `serviceAccount.create` value is set to "true", this
+	// field would contain "serviceAccount.create=true"
+	ValueToggle string
+	// DefaultEnabled is true when the Resource is created/enabled when the
+	// default values configuration is used during installation.
+	DefaultEnabled bool
+}
+
+// OptionalResources returns a slice of OptionalResourceMeta objects that
+// describe the optional Kubernetes Resources that the Helm Chart may install.
+func (c *Chart) OptionalResources(
+	ctx context.Context,
+) ([]*OptionalResource, error) {
+	hc := c.Chart
+	if hc == nil {
+		return nil, nil
+	}
+	ctx = debug.PushTrace(ctx, "helm:chart:optional-resources")
+	defer debug.PopTrace(ctx)
+	vs, err := c.loadValuesSchema(ctx)
+	if err != nil {
+		return nil, err
+	}
+	res := []*OptionalResource{}
+	if vs != nil {
+		// Look through the values schema property metadata for boolean
+		// "resource enablement" configuration toggles
+		for k, prop := range vs.Properties {
+			res = append(res, collectOptionalResources(
+				ctx, "", k, prop, nil)...,
+			)
+		}
+	}
+	return res, nil
+}
+
+var (
+	resourceTogglePropNames = []string{"create", "enabled"}
+)
+
+// collectOptionalResources recursively searches through a `jsonschema.Schema`
+// object's properties looking for "enabled" or "created" property names and
+// returning the discovered OptionalResource structs.
+func collectOptionalResources(
+	ctx context.Context,
+	dottedKey string,
+	propName string,
+	prop *jsonschema.Schema,
+	parent *jsonschema.Schema,
+) []*OptionalResource {
+	fullKey := propName
+	if dottedKey != "" {
+		fullKey = dottedKey + "." + propName
+	}
+	traceName := fmt.Sprintf(
+		"helm:chart:collect-optional-resource (%s)", fullKey,
+	)
+	ctx = debug.PushTrace(ctx, traceName)
+	defer debug.PopTrace(ctx)
+	if likelyResourceToggle(propName, prop) {
+		return []*OptionalResource{
+			{
+				ValueToggle:    fullKey,
+				DefaultEnabled: true,
+			},
+		}
+	}
+	res := []*OptionalResource{}
+	for k, p := range prop.Properties {
+		res = append(res, collectOptionalResources(
+			ctx, fullKey, k, p, prop)...,
+		)
+	}
+	return res
+}
+
+func likelyResourceToggle(
+	propName string,
+	prop *jsonschema.Schema,
+) bool {
+	if len(prop.Types) > 1 || prop.Types[0] != "boolean" {
+		return false
+	}
+	return lo.Contains(resourceTogglePropNames, strings.ToLower(propName))
+}

--- a/helm/resource_test.go
+++ b/helm/resource_test.go
@@ -1,0 +1,39 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package helm_test
+
+import (
+	"context"
+	"testing"
+
+	kihelm "github.com/jaypipes/kube-inspect/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionalResources(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.TODO()
+	c, err := kihelm.Inspect(
+		ctx, nginxLocalChartDir,
+	)
+	require.Nil(err)
+
+	require.NotNil(c.Metadata)
+	assert.Equal("nginx", c.Metadata.Name)
+	optResources, err := c.OptionalResources(ctx)
+	require.Nil(err)
+	toggles := []string{}
+	for _, r := range optResources {
+		toggles = append(toggles, r.ValueToggle)
+	}
+	// NOTE(jaypipes): The nginx Helm Chart in testdata contains only a partial
+	// JSONSchema that does not fully describe the entire values.yaml
+	// collection of configuration values. Notably, the "serviceAccount.create"
+	// property is missing (but the "pdb.create" property is present in the
+	// schema)
+	assert.Contains(toggles, "pdb.create")
+}

--- a/helm/schema.go
+++ b/helm/schema.go
@@ -1,0 +1,47 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package helm
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jaypipes/kube-inspect/debug"
+	"github.com/santhosh-tekuri/jsonschema"
+)
+
+const (
+	latestJSONSchemaDraftURL = "https://json-schema.org/schema"
+)
+
+// loadValuesSchema examines the Helm Chart's values JSONSChema and loads a
+// jsonschema.Schema object describing that document.
+//
+// We specifically do NOT use the same JSONSchema parsing/validation library
+// that the Helm sdk uses (https://github.com/xeipuuv/gojsonschema) because
+// that library has no introspection ability for the schema *itself*. We need
+// to be able to search through the JSONSchema's properties and do type/name
+// inspection.  We don't need to validate the JSONSchema (Helm already does
+// that).
+func (c *Chart) loadValuesSchema(
+	ctx context.Context,
+) (*jsonschema.Schema, error) {
+	hc := c.Chart
+	if hc == nil || hc.Schema == nil {
+		return nil, nil
+	}
+	ctx = debug.PushTrace(ctx, "helm:chart:load-jsonschema")
+	defer debug.PopTrace(ctx)
+	comp := jsonschema.NewCompiler()
+	comp.ExtractAnnotations = true
+	err := comp.AddResource(
+		latestJSONSchemaDraftURL,
+		strings.NewReader(string(hc.Schema)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return comp.Compile(latestJSONSchemaDraftURL)
+}


### PR DESCRIPTION
Adds a very basic discovery of optional resource creation/enablement toggles in the values.yaml JSONSchema for the Helm Chart. We look through the properties in the JSONSchema for anything that is "create" or "enabled" and guess that this values.yaml configuration path is a toggle (in a Helm template) to create a particular Kubernetes resource.