### PR TITLE
gracefully handle empty YAML documents

### DIFF
--- a/kube/resource.go
+++ b/kube/resource.go
@@ -40,6 +40,9 @@ func ResourcesFromManifest(
 		if err := decoder.Decode(&rawObj); err != nil {
 			break
 		}
+		if len(rawObj.Raw) == 0 {
+			continue
+		}
 
 		obj, gvk, err := parser.Decode(rawObj.Raw, nil, nil)
 		if err != nil {

--- a/kube/resource_test.go
+++ b/kube/resource_test.go
@@ -1,0 +1,92 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package kube_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jaypipes/kube-inspect/kube"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	singleDeploymentManifest    = filepath.Join("testdata", "deployment.yaml")
+	multipleDeploymentsManifest = filepath.Join("testdata", "deployments.yaml")
+	emptyDocumentManifest       = filepath.Join("testdata", "empty.yaml")
+)
+
+func TestResourcesFromManifest_SingleDeployment(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.TODO()
+	contents, err := os.ReadFile(singleDeploymentManifest)
+	require.Nil(err)
+
+	b := bytes.NewBuffer(contents)
+	resources, err := kube.ResourcesFromManifest(ctx, b)
+	require.Nil(err)
+	require.NotNil(resources)
+
+	resourceKinds := []string{}
+	for _, r := range resources {
+		resourceKinds = append(resourceKinds, r.GetKind())
+	}
+	resourceKinds = lo.Uniq(resourceKinds)
+	assert.Len(resources, 1)
+	assert.Contains(resourceKinds, "Deployment")
+	assert.Equal("nginx-deployment", resources[0].GetName())
+}
+
+func TestResourcesFromManifest_MultipleDeployments(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.TODO()
+	contents, err := os.ReadFile(multipleDeploymentsManifest)
+	require.Nil(err)
+
+	b := bytes.NewBuffer(contents)
+	resources, err := kube.ResourcesFromManifest(ctx, b)
+	require.Nil(err)
+	require.NotNil(resources)
+
+	resourceKinds := []string{}
+	for _, r := range resources {
+		resourceKinds = append(resourceKinds, r.GetKind())
+	}
+	resourceKinds = lo.Uniq(resourceKinds)
+	assert.Len(resources, 3)
+	assert.Len(resourceKinds, 1)
+	assert.Contains(resourceKinds, "Deployment")
+	assert.Equal("nginx-deployment1", resources[0].GetName())
+	assert.Equal("nginx-deployment2", resources[1].GetName())
+	assert.Equal("nginx-deployment3", resources[2].GetName())
+}
+
+func TestResourcesFromManifest_EmptyDocument(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.TODO()
+	contents, err := os.ReadFile(emptyDocumentManifest)
+	require.Nil(err)
+
+	b := bytes.NewBuffer(contents)
+	resources, err := kube.ResourcesFromManifest(ctx, b)
+	require.Nil(err)
+	require.NotNil(resources)
+
+	resourceKinds := []string{}
+	for _, r := range resources {
+		resourceKinds = append(resourceKinds, r.GetKind())
+	}
+	resourceKinds = lo.Uniq(resourceKinds)
+	assert.Len(resources, 1)
+	assert.Contains(resourceKinds, "Deployment")
+}

--- a/kube/testdata/deployment.yaml
+++ b/kube/testdata/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/kube/testdata/deployments.yaml
+++ b/kube/testdata/deployments.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment1
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment2
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment3
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---

--- a/kube/testdata/empty.yaml
+++ b/kube/testdata/empty.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---
+---


### PR DESCRIPTION
Ensure that we don't error when encountering empty YAML documents in the resource manifest being processed in `kube.ResourcesFromManifest()`.

Closes Issue #3