### PR TITLE
add Resource filtering functionality

### DIFF
--- a/helm/resource_test.go
+++ b/helm/resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	kihelm "github.com/jaypipes/kube-inspect/helm"
+	"github.com/jaypipes/kube-inspect/kube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,4 +37,32 @@ func TestOptionalResources(t *testing.T) {
 	// property is missing (but the "pdb.create" property is present in the
 	// schema)
 	assert.Contains(toggles, "pdb.create")
+}
+
+func TestFilterResourcesByName(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.TODO()
+	c, err := kihelm.Inspect(
+		ctx, nginxLocalChartDir,
+	)
+	require.Nil(err)
+
+	namedResources, err := c.Resources(ctx, kube.WithName("kube-inspect-nginx"))
+	require.Nil(err)
+	assert.Len(namedResources, 2)
+}
+
+func TestFilterResourcesByKind(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.TODO()
+	c, err := kihelm.Inspect(
+		ctx, nginxLocalChartDir,
+	)
+	require.Nil(err)
+
+	kindResources, err := c.Resources(ctx, kube.WithKind("ConfigMap"))
+	require.Nil(err)
+	assert.Len(kindResources, 1)
 }

--- a/kube/resourcer.go
+++ b/kube/resourcer.go
@@ -1,0 +1,41 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package kube
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ResourceFilter represents a filtering expression for Resources returned by a
+// call to `Resourcer.Resources()`
+type ResourceFilter func(res *unstructured.Unstructured, _ int) bool
+
+// Resourcer can return Resources that match zero or more filters.
+type Resourcer interface {
+	// Resources returns a slice of Kubernetes resources installed by the Helm
+	// Chart that match a supplied filter.
+	Resources(
+		ctx context.Context,
+		filters ...ResourceFilter,
+	) ([]*unstructured.Unstructured, error)
+}
+
+// WithName returns a ResourceFilter that filters a Resource by
+// `metadata.name`.
+func WithName(name string) ResourceFilter {
+	return func(res *unstructured.Unstructured, _ int) bool {
+		return res.GetName() == name
+	}
+}
+
+// WithKind returns a ResourceFilter that filters a Resource by
+// `metadata.kind`.
+func WithKind(kind string) ResourceFilter {
+	return func(res *unstructured.Unstructured, _ int) bool {
+		return res.GetKind() == kind
+	}
+}


### PR DESCRIPTION
Adds a new `kube/Resourcer` interface and `kube/ResourceFilter` type and adapts the `helm/Chart.Resources()` method signature to abide by the new interface. Resources can now be easily filtered by name or kind:

```go
ctx := context.TODO()
c, err := kihelm.Inspect(
    ctx, nginxLocalChartDir,
)

namedResources, _ := c.Resources(ctx, kube.WithName("kube-inspect-nginx"))
kindResources, _ := c.Resources(ctx, kube.WithKind("ConfigMap"))
```