### PR TITLE
add `kube.DiffResources()` and transform functions

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -27,6 +27,23 @@ type Diff struct {
 	dyff.Report
 }
 
+// ResourcesDiff describes the differences between two collections of
+// Kubernetes Resources.
+type ResourcesDiff struct {
+	// Changed is a map, keyed by full resource name
+	// (APIGroupVersion/ResourceName) of resources different between Charts A
+	// and B.
+	Changed map[string]Diff
+	// Added contains resources present in Chart B that are not present in
+	// Chart A.
+	Added []*unstructured.Unstructured
+	// Removed contains resources present in Chart A that are not present in
+	// Chart B.
+	Removed []*unstructured.Unstructured
+	// Unchanged contains resources that are exactly the same in both Charts.
+	Unchanged []*unstructured.Unstructured
+}
+
 // String returns a formatted string containing the diff of the compared
 // documents.
 func (d *Diff) String() string {

--- a/helm/diff.go
+++ b/helm/diff.go
@@ -7,33 +7,16 @@ package helm
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/jaypipes/kube-inspect/diff"
-	"github.com/samber/lo"
+	"github.com/jaypipes/kube-inspect/kube"
 	"gopkg.in/yaml.v3"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
-
-type ResourcesDiff struct {
-	// Changed is a map, keyed by full resource name
-	// (APIGroupVersion/ResourceName) of resources different between Charts A
-	// and B.
-	Changed map[string]diff.Diff
-	// Added contains resources present in Chart B that are not present in
-	// Chart A.
-	Added []*unstructured.Unstructured
-	// Removed contains resources present in Chart A that are not present in
-	// Chart B.
-	Removed []*unstructured.Unstructured
-	// Unchanged contains resources that are exactly the same in both Charts.
-	Unchanged []*unstructured.Unstructured
-}
 
 type ChartDiff struct {
 	// Resources describes the synthesized Kubernetes resources/manifests that
 	// are different between the Charts.
-	Resources ResourcesDiff `yaml:"resources"`
+	Resources diff.ResourcesDiff `yaml:"resources"`
 	// Values describes the values.yaml fields that are different between the
 	// Charts.
 	Values diff.Diff `yaml:"values"`
@@ -85,84 +68,14 @@ func resourcesDiff(
 	ctx context.Context,
 	a *Chart,
 	b *Chart,
-) (*ResourcesDiff, error) {
-	aResGroups, err := resourceGroupsFromChart(ctx, a)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get resources from chart A: %w", err)
-	}
-	bResGroups, err := resourceGroupsFromChart(ctx, b)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get resources from chart B: %w", err)
-	}
-	var additions, removals, unchanged []*unstructured.Unstructured
-	changes := map[string]diff.Diff{}
-
-	for aKind, aNameResources := range aResGroups {
-		if _, ok := bResGroups[aKind]; !ok {
-			removals = append(removals, lo.Values(aNameResources)...)
-			continue
-		}
-
-		for aName, aRes := range aNameResources {
-			bRes, ok := bResGroups[aKind][aName]
-			if !ok {
-				removals = append(removals, aRes)
-				continue
-			}
-			report, err := diff.New(aRes, bRes)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get dyff report: %w", err)
-			}
-			if len(report.Diffs) > 0 {
-				changes[aName] = *report
-			} else {
-				unchanged = append(unchanged, aRes)
-			}
-		}
-	}
-
-	for bKind, bNameResources := range bResGroups {
-		if _, ok := aResGroups[bKind]; !ok {
-			removals = append(removals, lo.Values(bNameResources)...)
-			continue
-		}
-		for bName, bRes := range bNameResources {
-			if _, ok := aResGroups[bKind][bName]; !ok {
-				additions = append(additions, bRes)
-			}
-		}
-	}
-
-	return &ResourcesDiff{
-		Changed:   changes,
-		Added:     additions,
-		Removed:   removals,
-		Unchanged: unchanged,
-	}, nil
-}
-
-// resourceGroupsFromChart returns a map, keyed by Resource Kind, of maps,
-// keyed by Resource Name, of Kubernetes Resources. The resource name will be
-// stripped of the "kube-inspect-" prefix that we tack on while templating the
-// Helm release.
-func resourceGroupsFromChart(
-	ctx context.Context,
-	chart *Chart,
-) (map[string]map[string]*unstructured.Unstructured, error) {
-	rs, err := chart.Resources(ctx)
+) (*diff.ResourcesDiff, error) {
+	ars, err := a.Resources(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	res := map[string]map[string]*unstructured.Unstructured{}
-	for _, r := range rs {
-		if _, ok := res[r.GetKind()]; !ok {
-			res[r.GetKind()] = map[string]*unstructured.Unstructured{}
-		}
-		if strings.HasPrefix(r.GetName(), "kube-inspect-") {
-			r.SetName(strings.TrimPrefix(r.GetName(), "kube-inspect-"))
-		}
-		res[r.GetKind()][r.GetName()] = r
+	brs, err := b.Resources(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return res, nil
+	return kube.DiffResources(ars, brs)
 }

--- a/kube/transform.go
+++ b/kube/transform.go
@@ -1,0 +1,95 @@
+package kube
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// ToUnstructured takes a variadic subject that can be a `[]byte` or
+// `io.Reader` representing a YAML document/manifest or a `runtime.Object` and
+// converts it to an `*unstructured.Unstructured`.
+//
+// If the supplied subject is a `[]byte` or `io.Reader`, only a single YAML
+// document is read from the input stream.
+func ToUnstructured(
+	subject any,
+) (*unstructured.Unstructured, error) {
+	switch subject := subject.(type) {
+	case *unstructured.Unstructured:
+		return subject, nil
+	case runtime.Object:
+		us, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(subject)
+		return &unstructured.Unstructured{Object: us}, nil
+	case []byte:
+		return unstructuredFromBytes(subject)
+	case io.Reader:
+		b, err := io.ReadAll(subject)
+		if err != nil {
+			return nil, err
+		}
+		return unstructuredFromBytes(b)
+	}
+	return nil, nil
+}
+
+func unstructuredFromBytes(subject []byte) (*unstructured.Unstructured, error) {
+	reader := bytes.NewReader(subject)
+	decoder := yamlutil.NewYAMLOrJSONDecoder(reader, 100)
+	parser := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	for {
+		var rawObj runtime.RawExtension
+		if err := decoder.Decode(&rawObj); err != nil {
+			break
+		}
+		if len(rawObj.Raw) == 0 {
+			continue
+		}
+
+		obj, _, err := parser.Decode(rawObj.Raw, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		usMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+		if err != nil {
+			return nil, err
+		}
+
+		return &unstructured.Unstructured{Object: usMap}, nil
+	}
+	return nil, nil
+}
+
+// ToSliceUnstructured returns a `[]*unstructured.Unstructured` given a subject
+// that is a `[]runtime.Object`, `*unstructured.UnstructuredList`, or
+// `[]*unstructured.Unstructured`
+func ToSliceUnstructured(
+	subject any,
+) ([]*unstructured.Unstructured, error) {
+	switch subject := subject.(type) {
+	case []*unstructured.Unstructured:
+		return subject, nil
+	case []runtime.Object:
+		res := make([]*unstructured.Unstructured, len(subject))
+		for x, item := range subject {
+			// *unstructured.Unstructured implements runtime.Object...
+			res[x] = item.(*unstructured.Unstructured)
+		}
+		return res, nil
+	case *unstructured.UnstructuredList:
+		res := make([]*unstructured.Unstructured, len(subject.Items))
+		for x, item := range subject.Items {
+			res[x] = &item
+		}
+		return res, nil
+	default:
+		return nil, fmt.Errorf(
+			"unable to convert %T to []*unstructured.Unstructured", subject,
+		)
+	}
+}


### PR DESCRIPTION
Adds a `kube.DiffResources()` function that returns a `*diff.ResourcesDiff`. This allows the diff functionality to be used outside of the `helm/` package.

Adds `kube.ToUnstructured()` and `kube.ToSliceUnstructured()` that accepts variadic arguments and return `*unstructured.Unstructured` and `[]*unstructured.Unstructured` respectively.