### PR TITLE
Turn off color settings to fix diff formatting

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gonvenience/bunt"
 	"github.com/gonvenience/ytbx"
 	"github.com/homeport/dyff/pkg/dyff"
 	"gopkg.in/yaml.v3"
@@ -47,6 +48,7 @@ type ResourcesDiff struct {
 // String returns a formatted string containing the diff of the compared
 // documents.
 func (d *Diff) String() string {
+	bunt.SetColorSettings(bunt.OFF, bunt.OFF)
 	reportWriter := &dyff.DiffSyntaxReport{
 		PathPrefix:            "@@",
 		RootDescriptionPrefix: "#",

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
+	github.com/gonvenience/bunt v1.4.2
 	github.com/gonvenience/ytbx v1.4.7
 	github.com/homeport/dyff v1.10.2
 	github.com/samber/lo v1.49.1
@@ -59,7 +60,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/gonvenience/bunt v1.4.2 // indirect
 	github.com/gonvenience/idem v0.0.2 // indirect
 	github.com/gonvenience/neat v1.3.16 // indirect
 	github.com/gonvenience/term v1.0.4 // indirect


### PR DESCRIPTION
Color settings didn't work well with the diff outputs so turned them off.

Before:

```diff
@@ [1m(root level)[0m @@
! [38;2;199;196;63m+ seven map entries added:[0m
+   [1;38;2;0;128;0mapproveSignerNames:[0m
+   [38;2;0;128;0m-[0m [38;2;50;205;50m"issuers.cert-manager.io/*"[0m
+   [38;2;0;128;0m-[0m [38;2;50;205;50m"clusterissuers.cert-manager.io/*"[0m
+   [1;38;2;0;128;0mcrds:[0m
+   [38;2;0;51;0m  [0m[1;38;2;0;128;0menabled:[0m [38;2;50;205;50mfalse[0m
+   [38;2;0;51;0m  [0m[1;38;2;0;128;0mkeep:[0m [38;2;50;205;50mtrue[0m
+   [1;38;2;0;128;0mcreator:[0m [38;2;50;205;50mhelm[0m
+   [1;38;2;0;128;0mdisableAutoApproval:[0m [38;2;50;205;50mfalse[0m
+   [1;38;2;0;128;0menabled:[0m [38;2;50;205;50mtrue[0m
+   [1;38;2;0;128;0mextraObjects:[0m [38;2;85;107;47m[][0m
+   [1;38;2;0;128;0mhostAliases:[0m [38;2;85;107;47m[][0m

@@ [1mcainjector[0m @@
! [38;2;199;196;63m+ two map entries added:[0m
+   [1;38;2;0;128;0mextraEnv:[0m [38;2;85;107;47m[][0m
+   [1;38;2;0;128;0mserviceLabels:[0m [38;2;85;107;47m{}[0m

@@ [1mprometheus[0m.[1mservicemonitor[0m.[1mtargetPort[0m @@
! [38;2;199;196;63m± type change from [3;38;2;199;196;63mint[0;38;2;199;196;63m to [3;38;2;199;196;63mstring[0m
[38;2;185;49;27m- 9402[0m
[38;2;88;191;56m+ http-metrics[0m

@@ [1mstartupapicheck[0m @@
! [38;2;199;196;63m+ one map entry added:[0m
+   [1;38;2;0;128;0mextraEnv:[0m [38;2;85;107;47m[][0m

@@ [1mwebhook[0m @@
! [38;2;199;196;63m+ three map entries added:[0m
+   [1;38;2;0;128;0mextraEnv:[0m [38;2;85;107;47m[][0m
+   [1;38;2;0;128;0mserviceIPFamilies:[0m [38;2;85;107;47m[][0m
+   [1;38;2;0;128;0mserviceIPFamilyPolicy:[0m
```

After:

```diff
@@ (root level) @@
! + seven map entries added:
+   approveSignerNames:
+   - "issuers.cert-manager.io/*"
+   - "clusterissuers.cert-manager.io/*"
+   crds:
+     enabled: false
+     keep: true
+   creator: helm
+   disableAutoApproval: false
+   enabled: true
+   extraObjects: []
+   hostAliases: []

@@ cainjector @@
! + two map entries added:
+   extraEnv: []
+   serviceLabels: {}

@@ prometheus.servicemonitor.targetPort @@
! ± type change from int to string
- 9402
+ http-metrics

@@ startupapicheck @@
! + one map entry added:
+   extraEnv: []

@@ webhook @@
! + three map entries added:
+   extraEnv: []
+   serviceIPFamilies: []
+   serviceIPFamilyPolicy:
```