### PR TITLE
Add option to exclude diffs via regexps

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -45,6 +45,13 @@ type ResourcesDiff struct {
 	Unchanged []*unstructured.Unstructured
 }
 
+// ExcludeRegexp accepts regular expressions as input and returns a new report with differences for not matching those patterns
+func (d *Diff) ExcludeRegexp(regexps ...string) *Diff {
+	return &Diff{
+		d.Report.ExcludeRegexp(regexps...),
+	}
+}
+
 // String returns a formatted string containing the diff of the compared
 // documents.
 func (d *Diff) String() string {


### PR DESCRIPTION
Not all identified diffs are equally important, so sometimes it is useful to exclude some of them. As the underlying diff library has this functionality already implementing it here is a simple wrapper.